### PR TITLE
feat: scope delete action to certain roles

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -8,16 +8,54 @@ removeButton.classList.add(
   "btn-icon",
   "gl-mr-3"
 );
-removeButton.textContent = "Delete";
 removeButton.type = "button";
 
-export default (projectId: string | number, tagName: string) => {
-  const cloned = removeButton.cloneNode(true) as HTMLButtonElement;
+const span = document.createElement("span");
 
+export default ({
+  projectId,
+  tagName,
+  content,
+  disabled = false,
+}: {
+  projectId: string | number;
+  tagName: string;
+  content: string;
+  disabled?: boolean;
+}) => {
+  const cloned = removeButton.cloneNode(true) as HTMLButtonElement;
+  const clonedSpan = span.cloneNode(true);
+
+  clonedSpan.textContent = content;
+  cloned.appendChild(clonedSpan);
+  cloned.disabled = disabled;
+  if (disabled) {
+    cloned.classList.add("disabled");
+  }
   cloned.dataset.grruTagname = tagName;
 
   cloned.addEventListener("click", (e) => {
     e.preventDefault();
+    const target = e.target as HTMLButtonElement;
+    const spinnerContainer = document.createElement("span");
+    const spinner = document.createElement("span");
+    spinnerContainer.classList.add(
+      "gl-spinner-container",
+      "gl-button-icon",
+      "gl-button-loading-indicator"
+    );
+    spinner.setAttribute("aria-label", "Loading");
+    spinner.classList.add(
+      "align-text-botom",
+      "gl-spinner",
+      "gl-spinner-light",
+      "gl-spinner-sm"
+    );
+    spinnerContainer.appendChild(spinner);
+
+    target.firstChild!.textContent = "Loading";
+    target.insertBefore(spinnerContainer, target.firstChild);
+
     const proceed = confirm("Are you sure about this?");
     if (proceed) {
       chrome.runtime.sendMessage(
@@ -25,10 +63,13 @@ export default (projectId: string | number, tagName: string) => {
           type: DELETE_RELEASE,
           payload: { origin: window.location.origin, projectId, tagName },
         },
-        () =>
+        () => {
+          target.removeChild(spinnerContainer);
+          target.firstChild!.textContent = content;
           window.location.replace(
             `${window.location.href.split("/-/")[0]}/-/releases`
-          )
+          );
+        }
       );
     }
   });

--- a/src/const.ts
+++ b/src/const.ts
@@ -5,6 +5,9 @@ export const ON_RELEASES_FETCH_COMPLETED = "on-releases-fetch-completed";
 export const GITLAB_LIST_RELEASES_API_PATTERN =
   "*://*/api/v4/projects/*/releases*";
 export const GITLAB_LIST_RELEASES_API_GRAPHQL_PATTERN = "*://*/api/graphql*";
+export const GITLAB_MEMBERS_API = "api/v4/projects/:id/members/all";
+export const GITLAB_CURRENT_USER_API = "api/v4/user";
 export type Operation = "on-releases-fetch-completed" | "delete-release";
 export const CSRF_TOKEN_KEY = "X-CSRF-Token";
 export const REQUESTED_WITH_KEY = "X-Requested-With";
+export const ACCESS_LEVEL_REQUIRED = 30; // https://docs.gitlab.com/ee/api/access_requests.html

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -1,7 +1,7 @@
 import { GITLAB_RELEASE_BLOCK_CLASSNAME, Request } from "const";
 import RemoveButton from "button";
 
-function scan() {
+function scan(canRemove: boolean) {
   const blocks = document.querySelectorAll<HTMLDivElement>(
     `.${GITLAB_RELEASE_BLOCK_CLASSNAME}`
   );
@@ -16,17 +16,21 @@ function scan() {
     );
     if (existed) return;
     const [, group, project] = window.location.pathname.split("/");
-    b.firstChild?.appendChild(RemoveButton(`${group}/${project}`, b.id));
+    b.firstChild?.appendChild(
+      RemoveButton({
+        projectId: `${group}/${project}`,
+        tagName: b.id,
+        content: canRemove ? "Delete" : "Your role is not allowed to delete",
+        disabled: !canRemove,
+      })
+    );
   });
 }
-
-let timer: number;
 
 chrome.runtime.onMessage.addListener(function (request: Request, _1, _2) {
   switch (request.type) {
     case "on-releases-fetch-completed":
-      clearTimeout(timer);
-      timer = setTimeout(scan, 1000);
+      scan(request.payload.canRemove);
       break;
     default:
       break;


### PR DESCRIPTION
## What this PR does
- [x] Scope the delete action to certain roles according to the issue's spec - https://gitlab.com/gitlab-org/gitlab/-/issues/213862 - only `developer` and above should be able to perform the action
- [x] Add a disabled button telling user if they do not have sufficient role to delete